### PR TITLE
fix(form value) add sane default for datetime

### DIFF
--- a/lib/ProMotion/form/form.rb
+++ b/lib/ProMotion/form/form.rb
@@ -79,6 +79,7 @@ module ProMotion
         case f[:type]
         when :date then NSDate.date
         when :time then NSDate.date
+        when :datetime then NSDate.date
         else ""
         end
       end


### PR DESCRIPTION
Related to: https://github.com/clearsightstudio/ProMotion-form/issues/19

I was getting this issue with datetime fields.