### PR TITLE
Fixes exception when using the label key on a cell

### DIFF
--- a/app/test_screens/test_form_screen.rb
+++ b/app/test_screens/test_form_screen.rb
@@ -31,7 +31,12 @@ class TestFormScreen < PM::FormScreen
           },
           backgroundColor: UIColor.lightGrayColor
         }
-      }]
+      }, {
+      name: "readonly",
+      label: "Test",
+      type: :text,
+      value: "Using Label",
+    },]
     }, {
       title: "Custom Cell Class",
       cells: [{

--- a/lib/ProMotion/form/form.rb
+++ b/lib/ProMotion/form/form.rb
@@ -63,7 +63,7 @@ module ProMotion
       data.update(FormStyle.to_style(input[:style     ])) if input[:style     ]
 
       # pass non-helper keys to FXForms
-      helpers = [ :cell_class, :name, :style, :properties ]
+      helpers = [ :cell_class, :name, :style, :properties, :label ]
       (input.keys - helpers).each {|key| data[key] = input[key] }
 
       # process "after" helper keys

--- a/spec/unit_form_screen_spec.rb
+++ b/spec/unit_form_screen_spec.rb
@@ -75,6 +75,6 @@ describe "ProMotion::TestFormScreen unit" do
 
   it "allows setting the cell title using :label" do
     field = form_controller.sections[1].fields[1]
-    field.value.should.be == "Using Label"
+    field.title.should.be == "Test"
   end
 end

--- a/spec/unit_form_screen_spec.rb
+++ b/spec/unit_form_screen_spec.rb
@@ -22,7 +22,7 @@ describe "ProMotion::TestFormScreen unit" do
 
   it "contains cells" do
     form_controller.sections[0].fields.count.should == 3
-    form_controller.sections[1].fields.count.should == 1
+    form_controller.sections[1].fields.count.should == 2
   end
 
   it "provides a sensible default for cells without a :name" do
@@ -71,5 +71,10 @@ describe "ProMotion::TestFormScreen unit" do
     field = form_controller.sections[3].fields[1]
     settings = field.cellConfig
     settings['imageView.image'].class.should == UIImage
+  end
+
+  it "allows setting the cell title using :label" do
+    field = form_controller.sections[1].fields[1]
+    field.value.should.be == "Using Label"
   end
 end


### PR DESCRIPTION
This allows the usage of the :label key to set the value of the displayed cell title.  

Fixes #28 